### PR TITLE
Use Helm provider v3 nested-attribute syntax

### DIFF
--- a/kro-and-ack/bootstrap/terraform/main.tf
+++ b/kro-and-ack/bootstrap/terraform/main.tf
@@ -25,10 +25,10 @@ provider "kubernetes" {
 }
 
 provider "helm" {
-  kubernetes {
+  kubernetes = {
     host                   = module.eks.cluster_endpoint
     cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
-    exec {
+    exec = {
       api_version = "client.authentication.k8s.io/v1beta1"
       args        = ["eks", "get-token", "--cluster-name", local.name, "--region", local.region]
       command     = "aws"

--- a/kro-and-ack/bootstrap/terraform/versions.tf
+++ b/kro-and-ack/bootstrap/terraform/versions.tf
@@ -19,7 +19,7 @@ terraform {
 
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 2.13"
+      version = ">= 3.0"
     }
   }
 


### PR DESCRIPTION
Update the helm provider block to the v3 kubernetes = { ... } / exec = { ... } attribute form and pin hashicorp/helm to >= 3.0 to match.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
